### PR TITLE
New feature: given a node, go backward to a unique xpath expression

### DIFF
--- a/test/clj_xpath/test/core.clj
+++ b/test/clj_xpath/test/core.clj
@@ -119,12 +119,12 @@
   (let [dom (xml->doc labels-xml)
         root (first ($x "/labels" dom))
         children @(:children root)]
-    (is (= "/labels[1]"           (abs-path root dom)))
-    (is (= "/labels[1]/text()[1]" (abs-path (first children) dom)))
-    (is (= "/labels[1]/label[1]"  (abs-path (second children) dom)))
-    (is (= "/labels[1]/text()[2]" (abs-path (nth children 2) dom)))
-    (is (= "/labels[1]/label[2]"  (abs-path (nth children 3) dom)))
-    (is (= "/labels[1]/text()[3]" (abs-path (nth children 4) dom)))))
+    (is (= "/labels[1]"           (abs-path root)))
+    (is (= "/labels[1]/text()[1]" (abs-path (first children))))
+    (is (= "/labels[1]/label[1]"  (abs-path (second children))))
+    (is (= "/labels[1]/text()[2]" (abs-path (nth children 2))))
+    (is (= "/labels[1]/label[2]"  (abs-path (nth children 3))))
+    (is (= "/labels[1]/text()[3]" (abs-path (nth children 4))))))
 
 (comment
 


### PR DESCRIPTION
New function clj-xpath.core/abs-path.

It takes a node (in the map form returned by $x and company) and constructs a unique xpath expression to locate that node.

The expression isn't necessarily the one that was used to get to the node in the first place, but it will get _back_ to it reliably.
